### PR TITLE
Respect the Java System Property no.difi.vefa.validation.configuration.datadir

### DIFF
--- a/validate-lib/src/main/java/no/difi/vefa/validation/Validate.java
+++ b/validate-lib/src/main/java/no/difi/vefa/validation/Validate.java
@@ -1,5 +1,6 @@
 package no.difi.vefa.validation;
 
+import java.nio.file.FileSystems;
 import java.util.ArrayList;
 import java.util.List;
 import javax.xml.parsers.DocumentBuilder;
@@ -44,7 +45,7 @@ public class Validate {
 	/**
 	 * Path to properties file.
 	 */	
-	public String pathToPropertiesFile = "/etc/opt/VEFAvalidator/validator.properties";
+	public String pathToPropertiesFile;
 
 	/**
 	 * Should the current validation suppress warnings from output? Default false.
@@ -77,6 +78,26 @@ public class Validate {
 	 */	
 	private PropertiesFile propertiesFile;
 
+        
+        public Validate() {
+            //Initiate path to property file
+            String datadir;
+            String defaultDatadir = "/etc/opt/VEFAvalidator";
+            String defaultFilename = "validator.properties";
+            String customDatadir = System.getProperty("no.difi.vefa.validation.configuration.datadir");
+	    
+            if (customDatadir != null)
+                datadir = customDatadir;
+            else
+                datadir = defaultDatadir;
+            
+            String separator = FileSystems.getDefault().getSeparator();
+            if(!datadir.endsWith(separator))
+                datadir += separator;
+            
+            this.pathToPropertiesFile = datadir + defaultFilename;
+             
+        }
 	/**
 	 * Executes a rendering according to the given configuration,
 	 * adds messages to the message collection if any and 

--- a/validate-lib/src/main/java/no/difi/vefa/validation/Validate.java
+++ b/validate-lib/src/main/java/no/difi/vefa/validation/Validate.java
@@ -247,17 +247,13 @@ public class Validate {
 	 * @throws Exception 
 	 */	
 	public PropertiesFile getPropertiesFile() throws Exception {
-		String VEFAvalidatorDataDir = System.getProperty("no.difi.vefa.validation.configuration.datadir");
-		
-		if (VEFAvalidatorDataDir != null) {
-			this.pathToPropertiesFile = VEFAvalidatorDataDir + "/validator.properties";
-		}
-		
 		PropertiesFile propFile = new PropertiesFile();
 		propFile.main(this.pathToPropertiesFile);
 		
-		if (VEFAvalidatorDataDir != null) {
-			propFile.dataDir = VEFAvalidatorDataDir; 
+                String customDatadir = System.getProperty("no.difi.vefa.validation.configuration.datadir");
+                
+		if (customDatadir != null) {
+			propFile.dataDir = customDatadir; 
 		}
 		
 		return propFile;


### PR DESCRIPTION
Even though `no.difi.vefa.validation.configuration.datadir`was set, parts of the application used the default value before getPropertiesFile() would initiate and change the public property based on the System property.

This request fixes #17 